### PR TITLE
Fixes close finde after print

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ const VueHtmlToPaper = {
         win.document.close();
         win.focus();
         win.print();
-        setTimeout(function () {window.close();}, 1);
+        setTimeout(function () {win.close();}, 1);
         cb();
       }, 1000);
         


### PR DESCRIPTION
The reference to the window opened it was wrong. In order to close the print window, `win` variable has to be used.