### PR TITLE
Vue 3 Prototype

### DIFF
--- a/build/vue-html-to-paper.js
+++ b/build/vue-html-to-paper.js
@@ -26,7 +26,7 @@
     
   const VueHtmlToPaper = {
     install (Vue, options = {}) {
-      Vue.prototype.$htmlToPaper = (el, localOptions, cb = () => true) => {
+      Vue.config.globalProperties.$htmlToPaper = (el, localOptions, cb = () => true) => {
         let defaultName = '_blank', 
           defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
           defaultReplace = true,

--- a/dist/index.js
+++ b/dist/index.js
@@ -24,7 +24,7 @@ function openWindow (url, name, props) {
   
 const VueHtmlToPaper = {
   install (Vue, options = {}) {
-    Vue.prototype.$htmlToPaper = (el, localOptions, cb = () => true) => {
+    Vue.config.globalProperties.$htmlToPaper = (el, localOptions, cb = () => true) => {
       let defaultName = '_blank', 
         defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
         defaultReplace = true,


### PR DESCRIPTION
Changing prototype instance into config.globalProperties for compatibility in Vue 3