### PR TITLE
Solve the problem of closing the page

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74,7 +74,7 @@ const VueHtmlToPaper = {
         win.document.close();
         win.focus();
         win.print();
-        setTimeout(function () {window.close();}, 1);
+        setTimeout(function () {win.close();}, 1);
         cb();
       }, 1000);
         


### PR DESCRIPTION
This error caused when a print request was created on a new page by canceling or printing the page - the page creating the print was closed.