### PR TITLE
🐛 fix: various bugs

### DIFF
--- a/build/vue-html-to-paper.js
+++ b/build/vue-html-to-paper.js
@@ -30,12 +30,15 @@
         let defaultName = '_blank', 
           defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
           defaultReplace = true,
-          defaultStyles = [];
+          defaultStyles = [],
+          defaultWindowTitle = window.document.title;
         let {
           name = defaultName,
           specs = defaultSpecs,
           replace = defaultReplace,
           styles = defaultStyles,
+          autoClose = true,
+          windowTitle = defaultWindowTitle,
         } = options;
 
         // If has localOptions
@@ -45,6 +48,8 @@
           if (localOptions.specs) specs = localOptions.specs;
           if (localOptions.replace) replace = localOptions.replace;
           if (localOptions.styles) styles = localOptions.styles;
+          if (localOptions.autoClose === false) autoClose = localOptions.autoClose;
+          if (localOptions.windowTitle) windowTitle = localOptions.windowTitle;
         }
 
         specs = !!specs.length ? specs.join(',') : '';
@@ -62,7 +67,7 @@
         win.document.write(`
         <html>
           <head>
-            <title>${window.document.title}</title>
+            <title>${windowTitle || window.document.title}</title>
           </head>
           <body>
             ${element.innerHTML}
@@ -73,10 +78,12 @@
         addStyles(win, styles);
         
         setTimeout(() => {
-          win.document.close();
           win.focus();
           win.print();
-          setTimeout(function () {window.close();}, 1);
+          console.warn('autoClose', autoClose);
+          if (autoClose) {
+            setTimeout(function () {win.close();}, 1);
+          }
           cb();
         }, 1000);
           

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,12 +28,15 @@ const VueHtmlToPaper = {
       let defaultName = '_blank', 
         defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
         defaultReplace = true,
-        defaultStyles = [];
+        defaultStyles = [],
+        defaultWindowTitle = window.document.title;
       let {
         name = defaultName,
         specs = defaultSpecs,
         replace = defaultReplace,
         styles = defaultStyles,
+        autoClose = true,
+        windowTitle = defaultWindowTitle,
       } = options;
 
       // If has localOptions
@@ -43,6 +46,8 @@ const VueHtmlToPaper = {
         if (localOptions.specs) specs = localOptions.specs;
         if (localOptions.replace) replace = localOptions.replace;
         if (localOptions.styles) styles = localOptions.styles;
+        if (localOptions.autoClose === false) autoClose = localOptions.autoClose;
+        if (localOptions.windowTitle) windowTitle = localOptions.windowTitle;
       }
 
       specs = !!specs.length ? specs.join(',') : '';
@@ -60,7 +65,7 @@ const VueHtmlToPaper = {
       win.document.write(`
         <html>
           <head>
-            <title>${window.document.title}</title>
+            <title>${windowTitle || window.document.title}</title>
           </head>
           <body>
             ${element.innerHTML}
@@ -71,10 +76,12 @@ const VueHtmlToPaper = {
       addStyles(win, styles);
       
       setTimeout(() => {
-        win.document.close();
         win.focus();
         win.print();
-        setTimeout(function () {window.close();}, 1);
+        console.warn('autoClose', autoClose);
+        if (autoClose) {
+          setTimeout(function () {win.close();}, 1);
+        }
         cb();
       }, 1000);
         

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
         },
         async printCustomWindowTitle() {
           const localOptions = {
-            windowTitle: 'This is custom window title',
+            windowTitle: 'This is a custom window title',
           };
           await this.$htmlToPaper('printMe', localOptions);
           console.warn('done');

--- a/src/index.js
+++ b/src/index.js
@@ -28,12 +28,15 @@ const VueHtmlToPaper = {
       let defaultName = '_blank', 
         defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
         defaultReplace = true,
-        defaultStyles = [];
+        defaultStyles = [],
+        defaultWindowTitle = window.document.title;
       let {
         name = defaultName,
         specs = defaultSpecs,
         replace = defaultReplace,
         styles = defaultStyles,
+        autoClose = true,
+        windowTitle = defaultWindowTitle,
       } = options;
 
       // If has localOptions
@@ -43,6 +46,8 @@ const VueHtmlToPaper = {
         if (localOptions.specs) specs = localOptions.specs;
         if (localOptions.replace) replace = localOptions.replace;
         if (localOptions.styles) styles = localOptions.styles;
+        if (localOptions.autoClose === false) autoClose = localOptions.autoClose;
+        if (localOptions.windowTitle) windowTitle = localOptions.windowTitle;
       }
 
       specs = !!specs.length ? specs.join(',') : '';
@@ -60,7 +65,7 @@ const VueHtmlToPaper = {
       win.document.write(`
         <html>
           <head>
-            <title>${window.document.title}</title>
+            <title>${windowTitle || window.document.title}</title>
           </head>
           <body>
             ${element.innerHTML}
@@ -71,10 +76,12 @@ const VueHtmlToPaper = {
       addStyles(win, styles);
       
       setTimeout(() => {
-        win.document.close();
         win.focus();
         win.print();
-        setTimeout(function () {window.close();}, 1);
+        console.warn('autoClose', autoClose);
+        if (autoClose) {
+          setTimeout(function () {win.close();}, 1);
+        }
         cb();
       }, 1000);
         


### PR DESCRIPTION
Closes #97 
Closes #119
Closes #109 
Closes #107 
Closes #103 
Closes #101 

🔨 refactor(vue-html-to-paper.js): add support for window title and auto close

This commit adds support for two new options to the vue-html-to-paper.js file. The first option is `windowTitle` which allows the user to specify a custom title for the print window. The second option is `autoClose` which is a boolean value that determines whether or not the print window should automatically close after printing. If `autoClose` is set to false, the window will remain open after printing.

🐛 fix(index.js): add autoClose option to close window after printing ✨ feat(index.js): add windowTitle option to customize window title 🎨 style(index.html): update custom window title to be grammatically correct The autoClose option has been added to allow the window to be closed automatically after printing. The windowTitle option has been added to allow customization of the window title. The custom window title in index.html has been updated to be grammatically correct.

🔧 chore(index.js): add autoClose and windowTitle options to VueHtmlToPaper
This commit adds two new options to the VueHtmlToPaper object: autoClose and windowTitle. The autoClose option allows the user to specify whether the print window should automatically close after printing. The windowTitle option allows the user to specify a custom title for the print window. These options can be passed in as localOptions or as part of the global options object.