### PR TITLE
Extend support Vue 2 & 3 + useHtmlToPaper utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,234 @@
 # Vue HTML to Paper
 
-Vue 3 plugin for printing html elements.
+Vue plugin for printing html elements.
 
 ![npm](https://img.shields.io/npm/dw/vue-html-to-paper)
-
-### Vue 3
 
 
 [Demo](https://mycurelabs.github.io/vue-html-to-paper/)
 
 [GitBook Documentation](https://oss.mycure.md/v/vue-html-to-paper/)
 
+## Install
+
+```sh
+npm install vue-html-to-paper
+yarn add vue-html-to-paper
+```
+
+## Development Setup
+
+```
+npm install
+
+npm run build:all
+```
+
+## Usage
+
+### Vue 3, Vue 2
+- initialize in `main.ts|js` (optional)
+- use in component:
+```js
+<template>
+  <div>
+    <div id="printMe">
+      <h1>Print me!</h1>
+    </div>
+    <button @click="print">Print</button>
+  </div>
+<template>
+
+// options API
+<script>
+import { useHtmlToPaper } from "vue-html-to-paper";
+
+export default {
+  name: 'Component',
+  methods: {
+    print() {
+      useHtmlToPaper('printMe')
+    }
+  }
+}
+</script>
+
+// composition API
+<script setup>
+import { useHtmlToPaper } from "vue-html-to-paper";
+
+const print = () => {
+  useHtmlToPaper("printMe");
+};
+</script>
+
+```
+
+### Vue 3
+
+```js
+// main.js | ts
+import { createApp } from "vue";
+import App from "./App.vue";
+
+import { VueHtmlToPaper } from "vue-html-to-paper";
+
+const app = createApp(App);
+
+const options = {
+  name: '_blank',
+  specs: [
+    'fullscreen=yes',
+    'titlebar=yes',
+    'scrollbars=yes'
+  ],
+  styles: [
+    'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
+    'https://unpkg.com/kidlat-css/css/kidlat.css'
+  ],
+  timeout: 1000, // default timeout before the print window appears
+  autoClose: true, // if false, the window will not close after printing
+  windowTitle: window.document.title, // override the window title
+}
+
+app.use(VueHtmlToPaper, options);
+
+// or, using the defaults with no stylesheet
+app.use(VueHtmlToPaper);
+
+app.mount("#app");
+```
+
+**Options API**
+```js
+// Component.vue
+<template>
+  <div>
+    <div id="printMe">
+      <h1>Print me!</h1>
+    </div>
+    <button @click="print">Print</button>
+  </div>
+<template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent {
+  methods: {
+    print () {
+      // Pass the element id here
+      this.$.appContext.config.globalProperties.$htmlToPaper('printMe');
+    }
+  }
+}
+</script>
+```
+
+**Composition API**
+```js
+// Component.vue
+<template>
+  <div>
+    <div id="printMe">
+      <h1>Print me!</h1>
+    </div>
+    <button @click="print">Print</button>
+  </div>
+<template>
+
+<script setup>
+import { inject } from "vue";
+
+const htmlToPaper = inject("htmlToPaper")
+
+const print = () => {
+  htmlToPaper("printMe");
+};
+</script>
+```
+
+**Composition API + TypeScript**
+```js
+// Component.vue
+<template>
+  <div>
+    <div id="printMe">
+      <h1>Print me!</h1>
+    </div>
+    <button @click="print">Print</button>
+  </div>
+<template>
+
+<script lang="ts" setup>
+import { inject } from "vue";
+import { HtmlToPaper } from "vue-html-to-paper";
+
+const htmlToPaper = inject("htmlToPaper") as HtmlToPaper;
+
+const print = () => {
+  htmlToPaper("printMe");
+};
+</script>
+```
+
 ### Vue 2
 
-Vue 2 is now low priority support, but feel free to send PR to [v1](https://github.com/mycurelabs/vue-html-to-paper/tree/v1) branch, and I'll be happy to publish them.
+```js
+// main.js
+import Vue from 'vue'
+import App from './App.vue'
+import {VueHtmlToPaper} from 'vue-html-to-paper';
 
-There are no changes to the way you use the plugin nor the way you install it. You can still refer to the latest documentation.
+Vue.config.productionTip = false
 
-Version for Vue 2 - [v1.4.5](https://www.npmjs.com/package/vue-html-to-paper/v/1.4.5)
+const options = {
+  name: '_blank',
+  specs: [
+    'fullscreen=yes',
+    'titlebar=yes',
+    'scrollbars=yes'
+  ],
+  styles: [
+    'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
+    'https://unpkg.com/kidlat-css/css/kidlat.css'
+  ],
+  timeout: 1000, // default timeout before the print window appears
+  autoClose: true, // if false, the window will not close after printing
+  windowTitle: window.document.title, // override the window title
+}
+
+Vue.use(VueHtmlToPaper, options);
+
+// or, using the defaults with no stylesheet
+Vue.use(VueHtmlToPaper);
+
+new Vue({
+  render: h => h(App),
+}).$mount('#app')
+```
+
+```js
+// Component.vue
+<template>
+  <div>
+    <div id="printMe">
+      <h1>Print me!</h1>
+    </div>
+    <button @click="print">Print</button>
+  </div>
+<template>
+
+<script>
+export default {
+  name: 'Component',
+  methods: {
+    print() {
+      this.$htmlToPaper('printMe')
+    }
+  }
+}
+</script>
+```
 
 Made with ❤️ by [Joff Tiquez](https://twitter.com/jrtiquez)

--- a/build/vue-html-to-paper.js
+++ b/build/vue-html-to-paper.js
@@ -1,11 +1,11 @@
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-  typeof define === 'function' && define.amd ? define(factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.VueHtmlToPaper = factory());
-}(this, (function () { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.VueHtmlToPaper = {}));
+})(this, (function (exports) { 'use strict';
 
   function addStyles (win, styles) {
-    styles.forEach(style => {
+    styles.forEach((style) => {
       let link = win.document.createElement('link');
       link.setAttribute('rel', 'stylesheet');
       link.setAttribute('type', 'text/css');
@@ -23,75 +23,89 @@
     windowRef.focus();
     return windowRef;
   }
-    
+
+  let defaultOptions = {
+    name: '_blank',
+    specs: ['fullscreen=yes', 'titlebar=yes', 'scrollbars=yes'],
+    replace: true,
+    styles: [],
+    autoClose: true,
+    windowTitle: null,
+  };
+
+  const useHtmlToPaper = (el, localOptions = {}, cb = () => true) => {
+    const {
+      name,
+      specs,
+      replace,
+      styles,
+      autoClose,
+      windowTitle,
+    } = {
+      ...defaultOptions,
+      ...localOptions,
+    };
+
+    const formattedSpecs = !!specs.length ? specs.join(',') : '';
+
+    const element = window.document.getElementById(el);
+
+    if (!element) {
+      alert(`Element to print #${el} not found!`);
+      return;
+    }
+
+    const url = '';
+    const win = openWindow(url, name, formattedSpecs);
+
+    win.document.write(`
+    <html>
+      <head>
+        <title>${windowTitle || window.document.title}</title>
+      </head>
+      <body>
+        ${element.innerHTML}
+      </body>
+    </html>
+  `);
+
+    addStyles(win, styles);
+
+    setTimeout(() => {
+      win.focus();
+      win.print();
+      console.warn('autoClose', autoClose);
+      if (autoClose) {
+        setTimeout(function () {
+          win.close();
+        }, 1);
+      }
+      cb();
+    }, 1000);
+
+    return true;
+  };
+
   const VueHtmlToPaper = {
     install (app, options = {}) {
-      app.config.globalProperties.$htmlToPaper = (el, localOptions, cb = () => true) => {
-        let defaultName = '_blank', 
-          defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
-          defaultReplace = true,
-          defaultStyles = [],
-          defaultWindowTitle = window.document.title;
-        let {
-          name = defaultName,
-          specs = defaultSpecs,
-          replace = defaultReplace,
-          styles = defaultStyles,
-          autoClose = true,
-          windowTitle = defaultWindowTitle,
-        } = options;
-
-        // If has localOptions
-        // TODO: improve logic
-        if (!!localOptions) {
-          if (localOptions.name) name = localOptions.name;
-          if (localOptions.specs) specs = localOptions.specs;
-          if (localOptions.replace) replace = localOptions.replace;
-          if (localOptions.styles) styles = localOptions.styles;
-          if (localOptions.autoClose === false) autoClose = localOptions.autoClose;
-          if (localOptions.windowTitle) windowTitle = localOptions.windowTitle;
-        }
-
-        specs = !!specs.length ? specs.join(',') : '';
-
-        const element = window.document.getElementById(el);
-
-        if (!element) {
-          alert(`Element to print #${el} not found!`);
-          return;
-        }
-        
-        const url = '';
-        const win = openWindow(url, name, specs);
-
-        win.document.write(`
-        <html>
-          <head>
-            <title>${windowTitle || window.document.title}</title>
-          </head>
-          <body>
-            ${element.innerHTML}
-          </body>
-        </html>
-      `);
-
-        addStyles(win, styles);
-        
-        setTimeout(() => {
-          win.focus();
-          win.print();
-          console.warn('autoClose', autoClose);
-          if (autoClose) {
-            setTimeout(function () {win.close();}, 1);
-          }
-          cb();
-        }, 1000);
-          
-        return true;
+      defaultOptions = {
+        ...defaultOptions,
+        ...options,
       };
+
+      if (app.prototype) {
+        app.prototype.$htmlToPaper = useHtmlToPaper;
+      } else {
+        app.provide('htmlToPaper', useHtmlToPaper);
+
+        app.config.globalProperties.$htmlToPaper = useHtmlToPaper;
+      }
     },
   };
 
-  return VueHtmlToPaper;
+  exports.VueHtmlToPaper = VueHtmlToPaper;
+  exports.useHtmlToPaper = useHtmlToPaper;
 
-})));
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+}));

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
 function addStyles (win, styles) {
-  styles.forEach(style => {
+  styles.forEach((style) => {
     let link = win.document.createElement('link');
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('type', 'text/css');
@@ -21,73 +21,85 @@ function openWindow (url, name, props) {
   windowRef.focus();
   return windowRef;
 }
-  
+
+let defaultOptions = {
+  name: '_blank',
+  specs: ['fullscreen=yes', 'titlebar=yes', 'scrollbars=yes'],
+  replace: true,
+  styles: [],
+  autoClose: true,
+  windowTitle: null,
+};
+
+const useHtmlToPaper = (el, localOptions = {}, cb = () => true) => {
+  const {
+    name,
+    specs,
+    replace,
+    styles,
+    autoClose,
+    windowTitle,
+  } = {
+    ...defaultOptions,
+    ...localOptions,
+  };
+
+  const formattedSpecs = !!specs.length ? specs.join(',') : '';
+
+  const element = window.document.getElementById(el);
+
+  if (!element) {
+    alert(`Element to print #${el} not found!`);
+    return;
+  }
+
+  const url = '';
+  const win = openWindow(url, name, formattedSpecs);
+
+  win.document.write(`
+    <html>
+      <head>
+        <title>${windowTitle || window.document.title}</title>
+      </head>
+      <body>
+        ${element.innerHTML}
+      </body>
+    </html>
+  `);
+
+  addStyles(win, styles);
+
+  setTimeout(() => {
+    win.focus();
+    win.print();
+    console.warn('autoClose', autoClose);
+    if (autoClose) {
+      setTimeout(function () {
+        win.close();
+      }, 1);
+    }
+    cb();
+  }, 1000);
+
+  return true;
+};
+
 const VueHtmlToPaper = {
   install (app, options = {}) {
-    app.config.globalProperties.$htmlToPaper = (el, localOptions, cb = () => true) => {
-      let defaultName = '_blank', 
-        defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
-        defaultReplace = true,
-        defaultStyles = [],
-        defaultWindowTitle = window.document.title;
-      let {
-        name = defaultName,
-        specs = defaultSpecs,
-        replace = defaultReplace,
-        styles = defaultStyles,
-        autoClose = true,
-        windowTitle = defaultWindowTitle,
-      } = options;
-
-      // If has localOptions
-      // TODO: improve logic
-      if (!!localOptions) {
-        if (localOptions.name) name = localOptions.name;
-        if (localOptions.specs) specs = localOptions.specs;
-        if (localOptions.replace) replace = localOptions.replace;
-        if (localOptions.styles) styles = localOptions.styles;
-        if (localOptions.autoClose === false) autoClose = localOptions.autoClose;
-        if (localOptions.windowTitle) windowTitle = localOptions.windowTitle;
-      }
-
-      specs = !!specs.length ? specs.join(',') : '';
-
-      const element = window.document.getElementById(el);
-
-      if (!element) {
-        alert(`Element to print #${el} not found!`);
-        return;
-      }
-      
-      const url = '';
-      const win = openWindow(url, name, specs);
-
-      win.document.write(`
-        <html>
-          <head>
-            <title>${windowTitle || window.document.title}</title>
-          </head>
-          <body>
-            ${element.innerHTML}
-          </body>
-        </html>
-      `);
-
-      addStyles(win, styles);
-      
-      setTimeout(() => {
-        win.focus();
-        win.print();
-        console.warn('autoClose', autoClose);
-        if (autoClose) {
-          setTimeout(function () {win.close();}, 1);
-        }
-        cb();
-      }, 1000);
-        
-      return true;
+    defaultOptions = {
+      ...defaultOptions,
+      ...options,
     };
+
+    if (app.prototype) {
+      app.prototype.$htmlToPaper = useHtmlToPaper;
+    } else {
+      app.provide('htmlToPaper', useHtmlToPaper);
+
+      app.config.globalProperties.$htmlToPaper = useHtmlToPaper;
+    }
   },
 };
 
-exports.default = VueHtmlToPaper;
+exports.VueHtmlToPaper = VueHtmlToPaper;
+exports.useHtmlToPaper = useHtmlToPaper;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 function addStyles (win, styles) {
-  styles.forEach(style => {
+  styles.forEach((style) => {
     let link = win.document.createElement('link');
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('type', 'text/css');
@@ -10,7 +10,8 @@ function addStyles (win, styles) {
 
 function openWindow (url, name, props) {
   let windowRef = null;
-  if (/*@cc_on!@*/false) { // for IE only
+  if (/*@cc_on!@*/ false) {
+    // for IE only
     windowRef = window.open('', name, props);
     windowRef.close();
   }
@@ -21,73 +22,84 @@ function openWindow (url, name, props) {
   windowRef.focus();
   return windowRef;
 }
-  
+
+let defaultOptions = {
+  name: '_blank',
+  specs: ['fullscreen=yes', 'titlebar=yes', 'scrollbars=yes'],
+  replace: true,
+  styles: [],
+  autoClose: true,
+  windowTitle: null,
+};
+
+const useHtmlToPaper = (el, localOptions = {}, cb = () => true) => {
+  const {
+    name,
+    specs,
+    replace,
+    styles,
+    autoClose,
+    windowTitle,
+  } = {
+    ...defaultOptions,
+    ...localOptions,
+  };
+
+  const formattedSpecs = !!specs.length ? specs.join(',') : '';
+
+  const element = window.document.getElementById(el);
+
+  if (!element) {
+    alert(`Element to print #${el} not found!`);
+    return;
+  }
+
+  const url = '';
+  const win = openWindow(url, name, formattedSpecs);
+
+  win.document.write(`
+    <html>
+      <head>
+        <title>${windowTitle || window.document.title}</title>
+      </head>
+      <body>
+        ${element.innerHTML}
+      </body>
+    </html>
+  `);
+
+  addStyles(win, styles);
+
+  setTimeout(() => {
+    win.focus();
+    win.print();
+    console.warn('autoClose', autoClose);
+    if (autoClose) {
+      setTimeout(function () {
+        win.close();
+      }, 1);
+    }
+    cb();
+  }, 1000);
+
+  return true;
+};
+
 const VueHtmlToPaper = {
   install (app, options = {}) {
-    app.config.globalProperties.$htmlToPaper = (el, localOptions, cb = () => true) => {
-      let defaultName = '_blank', 
-        defaultSpecs = ['fullscreen=yes','titlebar=yes', 'scrollbars=yes'],
-        defaultReplace = true,
-        defaultStyles = [],
-        defaultWindowTitle = window.document.title;
-      let {
-        name = defaultName,
-        specs = defaultSpecs,
-        replace = defaultReplace,
-        styles = defaultStyles,
-        autoClose = true,
-        windowTitle = defaultWindowTitle,
-      } = options;
-
-      // If has localOptions
-      // TODO: improve logic
-      if (!!localOptions) {
-        if (localOptions.name) name = localOptions.name;
-        if (localOptions.specs) specs = localOptions.specs;
-        if (localOptions.replace) replace = localOptions.replace;
-        if (localOptions.styles) styles = localOptions.styles;
-        if (localOptions.autoClose === false) autoClose = localOptions.autoClose;
-        if (localOptions.windowTitle) windowTitle = localOptions.windowTitle;
-      }
-
-      specs = !!specs.length ? specs.join(',') : '';
-
-      const element = window.document.getElementById(el);
-
-      if (!element) {
-        alert(`Element to print #${el} not found!`);
-        return;
-      }
-      
-      const url = '';
-      const win = openWindow(url, name, specs);
-
-      win.document.write(`
-        <html>
-          <head>
-            <title>${windowTitle || window.document.title}</title>
-          </head>
-          <body>
-            ${element.innerHTML}
-          </body>
-        </html>
-      `);
-
-      addStyles(win, styles);
-      
-      setTimeout(() => {
-        win.focus();
-        win.print();
-        console.warn('autoClose', autoClose);
-        if (autoClose) {
-          setTimeout(function () {win.close();}, 1);
-        }
-        cb();
-      }, 1000);
-        
-      return true;
+    defaultOptions = {
+      ...defaultOptions,
+      ...options,
     };
+
+    if (app.prototype) {
+      app.prototype.$htmlToPaper = useHtmlToPaper;
+    } else {
+      app.provide('htmlToPaper', useHtmlToPaper);
+
+      app.config.globalProperties.$htmlToPaper = useHtmlToPaper;
+    }
   },
 };
-  
-export default VueHtmlToPaper;
+
+export {VueHtmlToPaper, useHtmlToPaper};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,10 +15,12 @@ interface Options {
 interface HtmlToPaper {
   (
     id: string | HTMLElement,
-    localOptions: Options,
+    localOptions?: Options,
     callback?: () => void
   ): Promise<void>
 }
+
+export const useHtmlToPaper: HtmlToPaper
 
 export const VueHtmlToPaper: Plugin<Options>
 


### PR DESCRIPTION
In this PR: 
- fixes problem with typescript definition
- suppoprt for Vue 3 compositon (inject) and options API
- support for Vue 2
- `useHtmlToPaper` utility function available in both Vue 2 and 3